### PR TITLE
Implement daily version cache using a file

### DIFF
--- a/bittensor/cli.py
+++ b/bittensor/cli.py
@@ -246,8 +246,8 @@ class cli:
         # If no_version_checking is not set or set as False in the config, version checking is done.
         if not self.config.get("no_version_checking", d=True):
             try:
-                bittensor.utils.version_checking()
-            except:
+                bittensor.utils.check_version()
+            except bittensor.utils.VersionCheckError:
                 # If version checking fails, inform user with an exception.
                 raise RuntimeError(
                     "To avoid internet-based version checking, pass --no_version_checking while running the CLI."

--- a/bittensor/utils/__init__.py
+++ b/bittensor/utils/__init__.py
@@ -24,7 +24,7 @@ import torch
 import scalecodec
 
 from .wallet_utils import *  # noqa F401
-from .version import version_checking
+from .version import version_checking, check_version, VersionCheckError
 
 RAOPERTAO = 1e9
 U16_MAX = 65535

--- a/bittensor/utils/__init__.py
+++ b/bittensor/utils/__init__.py
@@ -17,6 +17,8 @@
 # DEALINGS IN THE SOFTWARE.
 
 from typing import Callable, Union, List, Optional, Dict, Literal
+from pathlib import Path
+import time
 
 import bittensor
 import hashlib
@@ -29,6 +31,8 @@ from .wallet_utils import *  # noqa F401
 RAOPERTAO = 1e9
 U16_MAX = 65535
 U64_MAX = 18446744073709551615
+
+VERSION_CHECK_THRESHOLD = 86400
 
 
 def ss58_to_vec_u8(ss58_address: str) -> List[int]:
@@ -59,32 +63,85 @@ def unbiased_topk(values, k, dim=0, sorted=True, largest=True):
     return topk, permutation[indices]
 
 
-def version_checking(timeout: int = 15):
+def _get_version_file_path() -> Path:
+    return Path.home() / ".bittensor" / ".version"
+
+
+def _get_version_from_file(version_file: Path) -> Optional[str]:
+    if not version_file.exists():
+        bittensor.logging.debug("No bitensor version file found")
+        return None
+
+    mtime = version_file.stat().st_mtime
+    bittensor.logging.debug(f"Found version file, last modified: {mtime}")
+    diff = time.time() - mtime
+
+    if diff >= VERSION_CHECK_THRESHOLD:
+        bittensor.logging.debug("Version file expired")
+        return None
+
+    try:
+        return version_file.read_text()
+    except Exception as e:
+        bittensor.logging.error(f"Failed to read version file: {e}")
+        return None
+
+
+def _get_version_from_pypi(timeout: int = 15) -> str:
     try:
         bittensor.logging.debug(
             f"Checking latest Bittensor version at: {bittensor.__pipaddress__}"
         )
         response = requests.get(bittensor.__pipaddress__, timeout=timeout)
         latest_version = response.json()["info"]["version"]
-        version_split = latest_version.split(".")
-        latest_version_as_int = (
-            (100 * int(version_split[0]))
-            + (10 * int(version_split[1]))
-            + (1 * int(version_split[2]))
-        )
-
-        if latest_version_as_int > bittensor.__version_as_int__:
-            print(
-                "\u001b[33mBittensor Version: Current {}/Latest {}\nPlease update to the latest version at your earliest convenience. "
-                "Run the following command to upgrade:\n\n\u001b[0mpython -m pip install --upgrade bittensor".format(
-                    bittensor.__version__, latest_version
-                )
-            )
 
     except requests.exceptions.Timeout:
         bittensor.logging.error("Version check failed due to timeout")
     except requests.exceptions.RequestException as e:
         bittensor.logging.error(f"Version check failed due to request failure: {e}")
+    else:
+        return latest_version
+
+    raise
+
+
+def get_latest_version(timeout: int = 15) -> str:
+    version_file = _get_version_file_path()
+    latest_version = _get_version_from_file(version_file)
+
+    if not latest_version:
+        try:
+            latest_version = _get_version_from_pypi(timeout)
+        except Exception:
+            return None
+        try:
+            version_file.write_text(latest_version)
+        except Exception as e:
+            bittensor.logging.error(f"Failed to write version file: {e}")
+
+    return latest_version
+
+
+def version_checking(timeout: int = 15):
+    try:
+        latest_version = get_latest_version(timeout)
+    except Exception:
+        return
+
+    version_split = latest_version.split(".")
+    latest_version_as_int = (
+        (100 * int(version_split[0]))
+        + (10 * int(version_split[1]))
+        + (1 * int(version_split[2]))
+    )
+
+    if latest_version_as_int > bittensor.__version_as_int__:
+        print(
+            "\u001b[33mBittensor Version: Current {}/Latest {}\nPlease update to the latest version at your earliest convenience. "
+            "Run the following command to upgrade:\n\n\u001b[0mpython -m pip install --upgrade bittensor".format(
+                bittensor.__version__, latest_version
+            )
+        )
 
 
 def strtobool_with_default(

--- a/bittensor/utils/__init__.py
+++ b/bittensor/utils/__init__.py
@@ -30,8 +30,6 @@ RAOPERTAO = 1e9
 U16_MAX = 65535
 U64_MAX = 18446744073709551615
 
-VERSION_CHECK_THRESHOLD = 86400
-
 
 def ss58_to_vec_u8(ss58_address: str) -> List[int]:
     ss58_bytes: bytes = bittensor.utils.ss58_address_to_bytes(ss58_address)

--- a/bittensor/utils/__init__.py
+++ b/bittensor/utils/__init__.py
@@ -17,16 +17,14 @@
 # DEALINGS IN THE SOFTWARE.
 
 from typing import Callable, Union, List, Optional, Dict, Literal
-from pathlib import Path
-import time
 
 import bittensor
 import hashlib
-import requests
 import torch
 import scalecodec
 
 from .wallet_utils import *  # noqa F401
+from .version import version_checking
 
 RAOPERTAO = 1e9
 U16_MAX = 65535
@@ -61,87 +59,6 @@ def unbiased_topk(values, k, dim=0, sorted=True, largest=True):
         permuted_values, k, dim=dim, sorted=sorted, largest=largest
     )
     return topk, permutation[indices]
-
-
-def _get_version_file_path() -> Path:
-    return Path.home() / ".bittensor" / ".version"
-
-
-def _get_version_from_file(version_file: Path) -> Optional[str]:
-    if not version_file.exists():
-        bittensor.logging.debug("No bitensor version file found")
-        return None
-
-    mtime = version_file.stat().st_mtime
-    bittensor.logging.debug(f"Found version file, last modified: {mtime}")
-    diff = time.time() - mtime
-
-    if diff >= VERSION_CHECK_THRESHOLD:
-        bittensor.logging.debug("Version file expired")
-        return None
-
-    try:
-        return version_file.read_text()
-    except Exception as e:
-        bittensor.logging.error(f"Failed to read version file: {e}")
-        return None
-
-
-def _get_version_from_pypi(timeout: int = 15) -> str:
-    try:
-        bittensor.logging.debug(
-            f"Checking latest Bittensor version at: {bittensor.__pipaddress__}"
-        )
-        response = requests.get(bittensor.__pipaddress__, timeout=timeout)
-        latest_version = response.json()["info"]["version"]
-
-    except requests.exceptions.Timeout:
-        bittensor.logging.error("Version check failed due to timeout")
-    except requests.exceptions.RequestException as e:
-        bittensor.logging.error(f"Version check failed due to request failure: {e}")
-    else:
-        return latest_version
-
-    raise
-
-
-def get_latest_version(timeout: int = 15) -> str:
-    version_file = _get_version_file_path()
-    latest_version = _get_version_from_file(version_file)
-
-    if not latest_version:
-        try:
-            latest_version = _get_version_from_pypi(timeout)
-        except Exception:
-            return None
-        try:
-            version_file.write_text(latest_version)
-        except Exception as e:
-            bittensor.logging.error(f"Failed to write version file: {e}")
-
-    return latest_version
-
-
-def version_checking(timeout: int = 15):
-    try:
-        latest_version = get_latest_version(timeout)
-    except Exception:
-        return
-
-    version_split = latest_version.split(".")
-    latest_version_as_int = (
-        (100 * int(version_split[0]))
-        + (10 * int(version_split[1]))
-        + (1 * int(version_split[2]))
-    )
-
-    if latest_version_as_int > bittensor.__version_as_int__:
-        print(
-            "\u001b[33mBittensor Version: Current {}/Latest {}\nPlease update to the latest version at your earliest convenience. "
-            "Run the following command to upgrade:\n\n\u001b[0mpython -m pip install --upgrade bittensor".format(
-                bittensor.__version__, latest_version
-            )
-        )
 
 
 def strtobool_with_default(

--- a/bittensor/utils/version.py
+++ b/bittensor/utils/version.py
@@ -1,0 +1,89 @@
+from typing import Optional
+from pathlib import Path
+import time
+
+import bittensor
+import requests
+
+VERSION_CHECK_THRESHOLD = 86400
+
+
+def _get_version_file_path() -> Path:
+    return Path.home() / ".bittensor" / ".version"
+
+
+def _get_version_from_file(version_file: Path) -> Optional[str]:
+    if not version_file.exists():
+        bittensor.logging.debug("No bitensor version file found")
+        return None
+
+    mtime = version_file.stat().st_mtime
+    bittensor.logging.debug(f"Found version file, last modified: {mtime}")
+    diff = time.time() - mtime
+
+    if diff >= VERSION_CHECK_THRESHOLD:
+        bittensor.logging.debug("Version file expired")
+        return None
+
+    try:
+        return version_file.read_text()
+    except Exception as e:
+        bittensor.logging.error(f"Failed to read version file: {e}")
+        return None
+
+
+def _get_version_from_pypi(timeout: int = 15) -> str:
+    try:
+        bittensor.logging.debug(
+            f"Checking latest Bittensor version at: {bittensor.__pipaddress__}"
+        )
+        response = requests.get(bittensor.__pipaddress__, timeout=timeout)
+        latest_version = response.json()["info"]["version"]
+
+    except requests.exceptions.Timeout:
+        bittensor.logging.error("Version check failed due to timeout")
+    except requests.exceptions.RequestException as e:
+        bittensor.logging.error(f"Version check failed due to request failure: {e}")
+    else:
+        return latest_version
+
+    raise
+
+
+def get_latest_version(timeout: int = 15) -> str:
+    version_file = _get_version_file_path()
+    latest_version = _get_version_from_file(version_file)
+
+    if not latest_version:
+        try:
+            latest_version = _get_version_from_pypi(timeout)
+        except Exception:
+            return None
+        try:
+            version_file.write_text(latest_version)
+        except Exception as e:
+            bittensor.logging.error(f"Failed to write version file: {e}")
+
+    return latest_version
+
+
+def version_checking(timeout: int = 15):
+    try:
+        latest_version = get_latest_version(timeout)
+    except Exception:
+        return
+
+    version_split = latest_version.split(".")
+    latest_version_as_int = (
+        (100 * int(version_split[0]))
+        + (10 * int(version_split[1]))
+        + (1 * int(version_split[2]))
+    )
+
+    if latest_version_as_int > bittensor.__version_as_int__:
+        print(
+            "\u001b[33mBittensor Version: Current {}/Latest {}\nPlease update to the latest version at your earliest convenience. "
+            "Run the following command to upgrade:\n\n\u001b[0mpython -m pip install --upgrade bittensor".format(
+                bittensor.__version__, latest_version
+            )
+        )

--- a/bittensor/utils/version.py
+++ b/bittensor/utils/version.py
@@ -1,6 +1,7 @@
 from typing import Optional
 from pathlib import Path
 import time
+from packaging.version import Version
 
 import bittensor
 import requests
@@ -42,8 +43,7 @@ def _get_version_from_pypi(timeout: int = 15) -> str:
         return latest_version
     except requests.exceptions.RequestException:
         bittensor.logging.exception("Failed to get latest version from pypi")
-
-    raise
+        raise
 
 
 def get_and_save_latest_version(timeout: int = 15) -> str:
@@ -52,10 +52,8 @@ def get_and_save_latest_version(timeout: int = 15) -> str:
     if last_known_version := _get_version_from_file(version_file):
         return last_known_version
 
-    try:
-        latest_version = _get_version_from_pypi(timeout)
-    except Exception:
-        return None
+    latest_version = _get_version_from_pypi(timeout)
+
     try:
         version_file.write_text(latest_version)
     except OSError:
@@ -65,19 +63,9 @@ def get_and_save_latest_version(timeout: int = 15) -> str:
 
 
 def version_checking(timeout: int = 15):
-    try:
-        latest_version = get_and_save_latest_version(timeout)
-    except Exception:
-        return
+    latest_version = get_and_save_latest_version(timeout)
 
-    version_split = latest_version.split(".")
-    latest_version_as_int = (
-        (100 * int(version_split[0]))
-        + (10 * int(version_split[1]))
-        + (1 * int(version_split[2]))
-    )
-
-    if latest_version_as_int > bittensor.__version_as_int__:
+    if Version(latest_version) > Version(bittensor.__version__):
         print(
             "\u001b[33mBittensor Version: Current {}/Latest {}\nPlease update to the latest version at your earliest convenience. "
             "Run the following command to upgrade:\n\n\u001b[0mpython -m pip install --upgrade bittensor".format(

--- a/bittensor/utils/version.py
+++ b/bittensor/utils/version.py
@@ -14,20 +14,19 @@ def _get_version_file_path() -> Path:
 
 
 def _get_version_from_file(version_file: Path) -> Optional[str]:
-    if not version_file.exists():
+    try:
+        mtime = version_file.stat().st_mtime
+        bittensor.logging.debug(f"Found version file, last modified: {mtime}")
+        diff = time.time() - mtime
+
+        if diff >= VERSION_CHECK_THRESHOLD:
+            bittensor.logging.debug("Version file expired")
+            return None
+
+        return version_file.read_text()
+    except FileNotFoundError:
         bittensor.logging.debug("No bitensor version file found")
         return None
-
-    mtime = version_file.stat().st_mtime
-    bittensor.logging.debug(f"Found version file, last modified: {mtime}")
-    diff = time.time() - mtime
-
-    if diff >= VERSION_CHECK_THRESHOLD:
-        bittensor.logging.debug("Version file expired")
-        return None
-
-    try:
-        return version_file.read_text()
     except OSError:
         bittensor.logging.exception("Failed to read version file")
         return None

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,3 +10,4 @@ hypothesis==6.81.1
 flake8==7.0.0
 mypy==1.8.0
 types-retry==0.9.9.4
+freezegun==1.5.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -13,7 +13,7 @@ netaddr
 numpy
 msgpack-numpy-opentensor==0.5.0
 nest_asyncio
-packaging==24.0
+packaging
 pycryptodome>=3.18.0,<4.0.0
 pyyaml
 password_strength

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -13,6 +13,7 @@ netaddr
 numpy
 msgpack-numpy-opentensor==0.5.0
 nest_asyncio
+packaging==24.0
 pycryptodome>=3.18.0,<4.0.0
 pyyaml
 password_strength

--- a/tests/unit_tests/utils/test_utils.py
+++ b/tests/unit_tests/utils/test_utils.py
@@ -17,291 +17,64 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-import torch
-import bittensor.utils.weight_utils as weight_utils
+from pathlib import Path
 import pytest
+import bittensor
+from freezegun import freeze_time
+from datetime import datetime, timedelta
+
+from bittensor.utils import VERSION_CHECK_THRESHOLD, get_latest_version
+from unittest.mock import MagicMock
+from pytest_mock import MockerFixture
 
 
-def test_convert_weight_and_uids():
-    uids = torch.tensor(list(range(10)))
-    weights = torch.rand(10)
-    weight_utils.convert_weights_and_uids_for_emit(uids, weights)
-
-    # min weight < 0
-    weights[5] = -1
-    with pytest.raises(ValueError) as pytest_wrapped_e:
-        weight_utils.convert_weights_and_uids_for_emit(uids, weights)
-
-    # min uid < 0
-    weights[5] = 0
-    uids[3] = -1
-    with pytest.raises(ValueError) as pytest_wrapped_e:
-        weight_utils.convert_weights_and_uids_for_emit(uids, weights)
-
-    # len(uids) != len(weights)
-    uids[3] = 3
-    with pytest.raises(ValueError) as pytest_wrapped_e:
-        weight_utils.convert_weights_and_uids_for_emit(uids, weights[1:])
-
-    # sum(weights) == 0
-    weights = torch.zeros(10)
-    weight_utils.convert_weights_and_uids_for_emit(uids, weights)
-
-    # test for overflow and underflow
-    for _ in range(5):
-        uids = torch.tensor(list(range(10)))
-        weights = torch.rand(10)
-        weight_utils.convert_weights_and_uids_for_emit(uids, weights)
+@pytest.fixture
+def pypi_version():
+    return "6.9.3"
 
 
-def test_normalize_with_max_weight():
-    weights = torch.rand(1000)
-    wn = weight_utils.normalize_max_weight(weights, limit=0.01)
-    assert wn.max() <= 0.01
-
-    weights = torch.zeros(1000)
-    wn = weight_utils.normalize_max_weight(weights, limit=0.01)
-    assert wn.max() <= 0.01
-
-    weights = torch.rand(1000)
-    wn = weight_utils.normalize_max_weight(weights, limit=0.02)
-    assert wn.max() <= 0.02
-
-    weights = torch.zeros(1000)
-    wn = weight_utils.normalize_max_weight(weights, limit=0.02)
-    assert wn.max() <= 0.02
-
-    weights = torch.rand(1000)
-    wn = weight_utils.normalize_max_weight(weights, limit=0.03)
-    assert wn.max() <= 0.03
-
-    weights = torch.zeros(1000)
-    wn = weight_utils.normalize_max_weight(weights, limit=0.03)
-    assert wn.max() <= 0.03
-
-    # Check for Limit
-    limit = 0.001
-    weights = torch.rand(2000)
-    w = weights / weights.sum()
-    wn = weight_utils.normalize_max_weight(weights, limit=limit)
-    assert (w.max() >= limit and (limit - wn.max()).abs() < 0.001) or (
-        w.max() < limit and wn.max() < limit
-    )
-
-    # Check for Zeros
-    limit = 0.01
-    weights = torch.zeros(2000)
-    wn = weight_utils.normalize_max_weight(weights, limit=limit)
-    assert wn.max() == 1 / 2000
-
-    # Check for Ordering after normalization
-    weights = torch.rand(100)
-    wn = weight_utils.normalize_max_weight(weights, limit=1)
-    assert torch.equal(wn, weights / weights.sum())
-
-    # Check for eplison changes
-    eplison = 0.01
-    weights, _ = torch.sort(torch.rand(100))
-    x = weights / weights.sum()
-    limit = x[-10]
-    change = eplison * limit
-    y = weight_utils.normalize_max_weight(x, limit=limit - change)
-    z = weight_utils.normalize_max_weight(x, limit=limit + change)
-    assert (y - z).abs().sum() < eplison
+@pytest.fixture
+def mock_get_version_from_pypi(mocker: MockerFixture, pypi_version: str):
+    return mocker.patch("bittensor.utils._get_version_from_pypi", return_value=pypi_version, autospec=True)
 
 
-@pytest.mark.parametrize(
-    "test_id, n, uids, weights, expected",
-    [
-        ("happy-path-1", 3, [0, 1, 2], [15, 5, 80], torch.tensor([0.15, 0.05, 0.8])),
-        ("happy-path-2", 4, [1, 3], [50, 50], torch.tensor([0.0, 0.5, 0.0, 0.5])),
-    ],
-)
-def test_convert_weight_uids_and_vals_to_tensor_happy_path(
-    test_id, n, uids, weights, expected
-):
-    # Act
-    result = weight_utils.convert_weight_uids_and_vals_to_tensor(n, uids, weights)
+@pytest.fixture
+def version_file_path(mocker: MockerFixture, tmp_path: Path):
+    file_path = tmp_path / ".version"
 
-    # Assert
-    assert torch.allclose(result, expected), f"Failed {test_id}"
+    mocker.patch("bittensor.utils._get_version_file_path", return_value=file_path)
+    return file_path
 
 
-@pytest.mark.parametrize(
-    "test_id, n, uids, weights, expected",
-    [
-        ("edge_case_empty", 5, [], [], torch.zeros(5)),
-        ("edge_case_single", 1, [0], [100], torch.tensor([1.0])),
-        ("edge_case_all_zeros", 4, [0, 1, 2, 3], [0, 0, 0, 0], torch.zeros(4)),
-    ],
-)
-def test_convert_weight_uids_and_vals_to_tensor_edge_cases(
-    test_id, n, uids, weights, expected
-):
-    # Act
-    result = weight_utils.convert_weight_uids_and_vals_to_tensor(n, uids, weights)
+def test_get_latest_version_no_file(mock_get_version_from_pypi: MagicMock, version_file_path: Path, pypi_version: str):
+    assert not version_file_path.exists()
 
-    # Assert
-    assert torch.allclose(result, expected), f"Failed {test_id}"
+    assert get_latest_version() == pypi_version
+
+    mock_get_version_from_pypi.assert_called_once()
+    assert version_file_path.exists()
+    assert version_file_path.read_text() == pypi_version
 
 
-@pytest.mark.parametrize(
-    "test_id, n, uids, weights, exception",
-    [
-        ("error-case-mismatched-lengths", 3, [0, 1, 3, 4, 5], [10, 20, 30], IndexError),
-        ("error-case-negative-n", -1, [0, 1], [10, 20], RuntimeError),
-        ("error-case-invalid-uids", 3, [0, 3], [10, 20], IndexError),
-    ],
-)
-def test_convert_weight_uids_and_vals_to_tensor_error_cases(
-    test_id, n, uids, weights, exception
-):
-    # Act / Assert
-    with pytest.raises(exception):
-        weight_utils.convert_weight_uids_and_vals_to_tensor(n, uids, weights)
+@pytest.mark.parametrize('elapsed', [0, VERSION_CHECK_THRESHOLD - 5])
+def test_get_latest_version_file_fresh_check(mock_get_version_from_pypi: MagicMock, version_file_path: Path, elapsed: int):
+    now = datetime.utcnow()
+
+    version_file_path.write_text("6.9.5")
+
+    with freeze_time(now + timedelta(seconds=elapsed)):
+        assert get_latest_version() == "6.9.5"
+
+    mock_get_version_from_pypi.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    "test_id, n, uids, weights, subnets, expected",
-    [
-        (
-            "happy-path-1",
-            3,
-            [0, 1, 2],
-            [15, 5, 80],
-            [0, 1, 2],
-            torch.tensor([0.15, 0.05, 0.8]),
-        ),
-        (
-            "happy-path-2",
-            3,
-            [0, 2],
-            [300, 300],
-            [0, 1, 2],
-            torch.tensor([0.5, 0.0, 0.5]),
-        ),
-    ],
-)
-def test_convert_root_weight_uids_and_vals_to_tensor_happy_paths(
-    test_id, n, uids, weights, subnets, expected
-):
-    # Act
-    result = weight_utils.convert_root_weight_uids_and_vals_to_tensor(
-        n, uids, weights, subnets
-    )
+def test_get_latest_version_file_expired_check(mock_get_version_from_pypi: MagicMock, version_file_path: Path, pypi_version: str):
+    now = datetime.utcnow()
 
-    # Assert
-    assert torch.allclose(result, expected, atol=1e-4), f"Failed {test_id}"
+    version_file_path.write_text("6.9.5")
 
+    with freeze_time(now + timedelta(seconds=VERSION_CHECK_THRESHOLD + 1)):
+        assert get_latest_version() == pypi_version
 
-@pytest.mark.parametrize(
-    "test_id, n, uids, weights, subnets, expected",
-    [
-        (
-            "edge-1",
-            1,
-            [0],
-            [0],
-            [0],
-            torch.tensor([0.0]),
-        ),  # Single neuron with zero weight
-        (
-            "edge-2",
-            2,
-            [0, 1],
-            [0, 0],
-            [0, 1],
-            torch.tensor([0.0, 0.0]),
-        ),  # All zero weights
-    ],
-)
-def test_convert_root_weight_uids_and_vals_to_tensor_edge_cases(
-    test_id, n, uids, weights, subnets, expected
-):
-    # Act
-    result = weight_utils.convert_root_weight_uids_and_vals_to_tensor(
-        n, uids, weights, subnets
-    )
-
-    # Assert
-    assert torch.allclose(result, expected, atol=1e-4), f"Failed {test_id}"
-
-
-@pytest.mark.parametrize(
-    "test_id, n, uids, weights, subnets, exception",
-    [
-        ("error-1", 3, [1, 3], [100, 200], [1, 2], Exception),  # uid not in subnets
-        ("error-2", 3, [1, 2, 3], [100, 200], [1], Exception),  # More uids than subnets
-    ],
-)
-def test_convert_root_weight_uids_and_vals_to_tensor_error_cases(
-    test_id, n, uids, weights, subnets, exception
-):
-    # Act and Assert
-    with pytest.raises(exception):
-        weight_utils.convert_root_weight_uids_and_vals_to_tensor(
-            n, uids, weights, subnets
-        )
-        print(f"Failed {test_id}")
-
-
-@pytest.mark.parametrize(
-    "test_id, n, uids, bonds, expected_output",
-    [
-        (
-            "happy-path-1",
-            5,
-            [1, 3, 4],
-            [10, 20, 30],
-            torch.tensor([0, 10, 0, 20, 30], dtype=torch.int64),
-        ),
-        (
-            "happy-path-2",
-            3,
-            [0, 1, 2],
-            [7, 8, 9],
-            torch.tensor([7, 8, 9], dtype=torch.int64),
-        ),
-        ("happy-path-3", 4, [2], [15], torch.tensor([0, 0, 15, 0], dtype=torch.int64)),
-    ],
-)
-def test_happy_path(test_id, n, uids, bonds, expected_output):
-    # Act
-    result = weight_utils.convert_bond_uids_and_vals_to_tensor(n, uids, bonds)
-
-    # Assert
-    assert torch.equal(result, expected_output), f"Failed {test_id}"
-
-
-@pytest.mark.parametrize(
-    "test_id, n, uids, bonds, expected_output",
-    [
-        ("edge-1", 1, [0], [0], torch.tensor([0], dtype=torch.int64)),  # Single element
-        (
-            "edge-2",
-            10,
-            [],
-            [],
-            torch.zeros(10, dtype=torch.int64),
-        ),  # Empty uids and bonds
-    ],
-)
-def test_edge_cases(test_id, n, uids, bonds, expected_output):
-    # Act
-    result = weight_utils.convert_bond_uids_and_vals_to_tensor(n, uids, bonds)
-
-    # Assert
-    assert torch.equal(result, expected_output), f"Failed {test_id}"
-
-
-@pytest.mark.parametrize(
-    "test_id, n, uids, bonds, exception",
-    [
-        ("error-1", 5, [1, 3, 6], [10, 20, 30], IndexError),  # uid out of bounds
-        ("error-2", -1, [0], [10], RuntimeError),  # Negative number of neurons
-    ],
-)
-def test_error_cases(test_id, n, uids, bonds, exception):
-    # Act / Assert
-    with pytest.raises(exception):
-        weight_utils.convert_bond_uids_and_vals_to_tensor(n, uids, bonds)
+    mock_get_version_from_pypi.assert_called_once()
+    assert version_file_path.read_text() == pypi_version

--- a/tests/unit_tests/utils/test_version.py
+++ b/tests/unit_tests/utils/test_version.py
@@ -22,7 +22,7 @@ import pytest
 from freezegun import freeze_time
 from datetime import datetime, timedelta
 
-from bittensor.utils.version import VERSION_CHECK_THRESHOLD, get_latest_version
+from bittensor.utils.version import VERSION_CHECK_THRESHOLD, get_and_save_latest_version
 from unittest.mock import MagicMock
 from pytest_mock import MockerFixture
 
@@ -45,10 +45,10 @@ def version_file_path(mocker: MockerFixture, tmp_path: Path):
     return file_path
 
 
-def test_get_latest_version_no_file(mock_get_version_from_pypi: MagicMock, version_file_path: Path, pypi_version: str):
+def test_get_and_save_latest_version_no_file(mock_get_version_from_pypi: MagicMock, version_file_path: Path, pypi_version: str):
     assert not version_file_path.exists()
 
-    assert get_latest_version() == pypi_version
+    assert get_and_save_latest_version() == pypi_version
 
     mock_get_version_from_pypi.assert_called_once()
     assert version_file_path.exists()
@@ -56,24 +56,24 @@ def test_get_latest_version_no_file(mock_get_version_from_pypi: MagicMock, versi
 
 
 @pytest.mark.parametrize('elapsed', [0, VERSION_CHECK_THRESHOLD - 5])
-def test_get_latest_version_file_fresh_check(mock_get_version_from_pypi: MagicMock, version_file_path: Path, elapsed: int):
+def test_get_and_save_latest_version_file_fresh_check(mock_get_version_from_pypi: MagicMock, version_file_path: Path, elapsed: int):
     now = datetime.utcnow()
 
     version_file_path.write_text("6.9.5")
 
     with freeze_time(now + timedelta(seconds=elapsed)):
-        assert get_latest_version() == "6.9.5"
+        assert get_and_save_latest_version() == "6.9.5"
 
     mock_get_version_from_pypi.assert_not_called()
 
 
-def test_get_latest_version_file_expired_check(mock_get_version_from_pypi: MagicMock, version_file_path: Path, pypi_version: str):
+def test_get_and_save_latest_version_file_expired_check(mock_get_version_from_pypi: MagicMock, version_file_path: Path, pypi_version: str):
     now = datetime.utcnow()
 
     version_file_path.write_text("6.9.5")
 
     with freeze_time(now + timedelta(seconds=VERSION_CHECK_THRESHOLD + 1)):
-        assert get_latest_version() == pypi_version
+        assert get_and_save_latest_version() == pypi_version
 
     mock_get_version_from_pypi.assert_called_once()
     assert version_file_path.read_text() == pypi_version

--- a/tests/unit_tests/utils/test_version.py
+++ b/tests/unit_tests/utils/test_version.py
@@ -19,11 +19,10 @@
 
 from pathlib import Path
 import pytest
-import bittensor
 from freezegun import freeze_time
 from datetime import datetime, timedelta
 
-from bittensor.utils import VERSION_CHECK_THRESHOLD, get_latest_version
+from bittensor.utils.version import VERSION_CHECK_THRESHOLD, get_latest_version
 from unittest.mock import MagicMock
 from pytest_mock import MockerFixture
 
@@ -35,14 +34,14 @@ def pypi_version():
 
 @pytest.fixture
 def mock_get_version_from_pypi(mocker: MockerFixture, pypi_version: str):
-    return mocker.patch("bittensor.utils._get_version_from_pypi", return_value=pypi_version, autospec=True)
+    return mocker.patch("bittensor.utils.version._get_version_from_pypi", return_value=pypi_version, autospec=True)
 
 
 @pytest.fixture
 def version_file_path(mocker: MockerFixture, tmp_path: Path):
     file_path = tmp_path / ".version"
 
-    mocker.patch("bittensor.utils._get_version_file_path", return_value=file_path)
+    mocker.patch("bittensor.utils.version._get_version_file_path", return_value=file_path)
     return file_path
 
 


### PR DESCRIPTION
The idea in the original task was to simply touch a file, which works for preventing the request, but leads to a potential issue:
If we requested a version from the remote which happens to be newer than the current version, we will touch the file and not notify the user about upgrading on the next run, which is probably not the desired behavior. That's why I went a bit further with writing the actual version to the file. 